### PR TITLE
Add ImageBench to 7.3 Code Repositories & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,6 +886,7 @@ The latest arXiv-native multimodal papers increasingly blur the boundaries betwe
 |---|---|---|
 | **TorchUMM** | Unified evaluation, analysis and post-training toolkit for heterogeneous unified multimodal model architectures, tasks and datasets | [Paper](https://arxiv.org/abs/2604.10784) [Code](https://github.com/AIFrontierLab/TorchUMM) |
 | **LMMs-Eval** | Unified evaluation harness for multimodal models | [Code](https://github.com/EvolvingLMMs-Lab/lmms-eval) |
+| **ImageBench** | Live text-to-image benchmark ranking 40+ models on 192 prompts across 6 categories using VLM judges; every generated image is published for inspection | [Site](https://imagebench.ai) [Methodology](https://imagebench.ai/methodology-v1) |
 | **LAVIS** | Library for Language-Vision Intelligence (Salesforce) | [Code](https://github.com/salesforce/LAVIS) |
 | **OpenFlamingo** | Open reproduction of DeepMind Flamingo | [Code](https://github.com/mlfoundations/open_flamingo) |
 | **xtuner** | Efficient fine-tuning for multimodal LLMs | [Code](https://github.com/InternLM/xtuner) |


### PR DESCRIPTION
Adds ImageBench (imagebench.ai) as a single row in Section 7.3 (Code Repositories & Tools), next to LMMs-Eval.

Reason for inclusion:
- Ongoing text-to-image benchmark ranking 40+ current models (Flux 2, Nano Banana Pro, GPT Image 2, Ideogram, Seedream, Recraft, etc.) on 192 prompts across 6 categories
- Uses VLM (multimodal LLM) judges for capability scoring plus an Estimated Preference Score for aesthetic
- Every generated image is published, so per-model failures are inspectable rather than sampled
- Open methodology: https://imagebench.ai/methodology-v1

Kept the entry format identical to existing 7.3 rows. Happy to move to 7.1 (Related Awesome Lists) or drop it if 7.3 is meant strictly for training/eval libraries rather than benchmark sites.